### PR TITLE
tracee-ebpf: all tail calls registered as event dependencies

### DIFF
--- a/pkg/ebpf/events_definitions.go
+++ b/pkg/ebpf/events_definitions.go
@@ -22,13 +22,20 @@ type probe struct {
 	fn     string
 }
 
+type dependencies struct {
+	events    []eventDependency // Events required to be loaded and/or submitted for the event to happen
+	ksymbols  []string
+	tailCalls []tailCall
+}
+
 type eventDependency struct {
 	eventID int32
 }
 
-type dependencies struct {
-	events   []eventDependency // Events required to be loaded and/or submitted for the event to happen
-	ksymbols []string
+type tailCall struct {
+	mapName  string
+	mapIdx   uint32
+	progName string
 }
 
 // EventDefinition is a struct describing an event configuration
@@ -877,6 +884,11 @@ var EventsDefinitions = map[int32]EventDefinition{
 		Name:    "execve",
 		Probes: []probe{
 			{event: "execve", attach: sysCall, fn: "execve"},
+		},
+		Dependencies: dependencies{
+			tailCalls: []tailCall{
+				{mapName: "sys_enter_tails", mapIdx: uint32(ExecveEventID), progName: "syscall__execve"},
+			},
 		},
 		Sets: []string{"default", "syscalls", "proc", "proc_life"},
 		Params: []trace.ArgMeta{
@@ -4154,6 +4166,11 @@ var EventsDefinitions = map[int32]EventDefinition{
 		Probes: []probe{
 			{event: "execveat", attach: sysCall, fn: "execveat"},
 		},
+		Dependencies: dependencies{
+			tailCalls: []tailCall{
+				{mapName: "sys_enter_tails", mapIdx: uint32(ExecveatEventID), progName: "syscall__execveat"},
+			},
+		},
 		Sets: []string{"default", "syscalls", "proc", "proc_life"},
 		Params: []trace.ArgMeta{
 			{Type: "int", Name: "dirfd"},
@@ -6139,7 +6156,14 @@ var EventsDefinitions = map[int32]EventDefinition{
 		ID32Bit: sys32undefined,
 		Name:    "socket_dup",
 		Probes:  []probe{},
-		Sets:    []string{},
+		Dependencies: dependencies{
+			tailCalls: []tailCall{
+				{mapName: "sys_exit_tails", mapIdx: uint32(DupEventID), progName: "sys_dup_exit_tail"},
+				{mapName: "sys_exit_tails", mapIdx: uint32(Dup2EventID), progName: "sys_dup_exit_tail"},
+				{mapName: "sys_exit_tails", mapIdx: uint32(Dup3EventID), progName: "sys_dup_exit_tail"},
+			},
+		},
+		Sets: []string{},
 		Params: []trace.ArgMeta{
 			{Type: "int", Name: "oldfd"},
 			{Type: "int", Name: "newfd"},

--- a/pkg/ebpf/events_definitions.go
+++ b/pkg/ebpf/events_definitions.go
@@ -32,10 +32,30 @@ type eventDependency struct {
 	eventID int32
 }
 
+// an enum that specifies the index of a function to be used in a bpf tail call
+// tail function indexes should match defined values in ebpf code for prog_array map
+const (
+	tailVfsWrite uint32 = iota
+	tailVfsWritev
+	tailSendBin
+	tailSendBinTP
+	tailKernelWrite
+)
+
+type tailType uint8
+
+const (
+	CaptureFile tailType = iota
+	CaptureModule
+	CaptureMem
+	CaptureAlways
+)
+
 type tailCall struct {
 	mapName  string
 	mapIdx   uint32
 	progName string
+	tailType tailType
 }
 
 // EventDefinition is a struct describing an event configuration
@@ -249,6 +269,11 @@ var EventsDefinitions = map[int32]EventDefinition{
 		Probes: []probe{
 			{event: "mmap", attach: sysCall, fn: "mmap"},
 		},
+		Dependencies: dependencies{
+			tailCalls: []tailCall{
+				{mapName: "prog_array", mapIdx: tailSendBin, progName: "send_bin", tailType: CaptureMem},
+			},
+		},
 		Sets: []string{"syscalls", "proc", "proc_mem"},
 		Params: []trace.ArgMeta{
 			{Type: "void*", Name: "addr"},
@@ -264,6 +289,11 @@ var EventsDefinitions = map[int32]EventDefinition{
 		Name:    "mprotect",
 		Probes: []probe{
 			{event: "mprotect", attach: sysCall, fn: "mprotect"},
+		},
+		Dependencies: dependencies{
+			tailCalls: []tailCall{
+				{mapName: "prog_array", mapIdx: tailSendBin, progName: "send_bin", tailType: CaptureMem},
+			},
 		},
 		Sets: []string{"syscalls", "proc", "proc_mem"},
 		Params: []trace.ArgMeta{
@@ -887,7 +917,7 @@ var EventsDefinitions = map[int32]EventDefinition{
 		},
 		Dependencies: dependencies{
 			tailCalls: []tailCall{
-				{mapName: "sys_enter_tails", mapIdx: uint32(ExecveEventID), progName: "syscall__execve"},
+				{mapName: "sys_enter_tails", mapIdx: uint32(ExecveEventID), progName: "syscall__execve", tailType: CaptureAlways},
 			},
 		},
 		Sets: []string{"default", "syscalls", "proc", "proc_life"},
@@ -2259,6 +2289,13 @@ var EventsDefinitions = map[int32]EventDefinition{
 		Name:    "init_module",
 		Probes: []probe{
 			{event: "init_module", attach: sysCall, fn: "init_module"},
+		},
+		Dependencies: dependencies{
+			tailCalls: []tailCall{
+				{mapName: "sys_enter_tails", mapIdx: uint32(InitModuleEventID), progName: "syscall__init_module", tailType: CaptureModule},
+				{mapName: "prog_array_tp", mapIdx: tailSendBinTP, progName: "send_bin_tp", tailType: CaptureModule},
+				{mapName: "prog_array", mapIdx: tailSendBin, progName: "send_bin", tailType: CaptureModule},
+			},
 		},
 		Sets: []string{"default", "syscalls", "system", "system_module"},
 		Params: []trace.ArgMeta{
@@ -4168,7 +4205,7 @@ var EventsDefinitions = map[int32]EventDefinition{
 		},
 		Dependencies: dependencies{
 			tailCalls: []tailCall{
-				{mapName: "sys_enter_tails", mapIdx: uint32(ExecveatEventID), progName: "syscall__execveat"},
+				{mapName: "sys_enter_tails", mapIdx: uint32(ExecveatEventID), progName: "syscall__execveat", tailType: CaptureAlways},
 			},
 		},
 		Sets: []string{"default", "syscalls", "proc", "proc_life"},
@@ -5816,6 +5853,12 @@ var EventsDefinitions = map[int32]EventDefinition{
 			{event: "vfs_write", attach: kprobe, fn: "trace_vfs_write"},
 			{event: "vfs_write", attach: kretprobe, fn: "trace_ret_vfs_write"},
 		},
+		Dependencies: dependencies{
+			tailCalls: []tailCall{
+				{mapName: "prog_array", mapIdx: tailVfsWrite, progName: "trace_ret_vfs_write_tail", tailType: CaptureFile},
+				{mapName: "prog_array", mapIdx: tailSendBin, progName: "send_bin", tailType: CaptureFile},
+			},
+		},
 		Sets: []string{},
 		Params: []trace.ArgMeta{
 			{Type: "const char*", Name: "pathname"},
@@ -5832,6 +5875,12 @@ var EventsDefinitions = map[int32]EventDefinition{
 			{event: "vfs_writev", attach: kprobe, fn: "trace_vfs_writev"},
 			{event: "vfs_writev", attach: kretprobe, fn: "trace_ret_vfs_writev"},
 		},
+		Dependencies: dependencies{
+			tailCalls: []tailCall{
+				{mapName: "prog_array", mapIdx: tailVfsWritev, progName: "trace_ret_vfs_writev_tail", tailType: CaptureFile},
+				{mapName: "prog_array", mapIdx: tailSendBin, progName: "send_bin", tailType: CaptureFile},
+			},
+		},
 		Sets: []string{},
 		Params: []trace.ArgMeta{
 			{Type: "const char*", Name: "pathname"},
@@ -5847,6 +5896,11 @@ var EventsDefinitions = map[int32]EventDefinition{
 		Probes: []probe{
 			{event: "security_mmap_addr", attach: kprobe, fn: "trace_mmap_alert"},
 			{event: "security_file_mprotect", attach: kprobe, fn: "trace_mprotect_alert"},
+		},
+		Dependencies: dependencies{
+			tailCalls: []tailCall{
+				{mapName: "prog_array", mapIdx: tailSendBin, progName: "send_bin", tailType: CaptureMem},
+			},
 		},
 		Sets: []string{},
 		Params: []trace.ArgMeta{
@@ -6087,6 +6141,11 @@ var EventsDefinitions = map[int32]EventDefinition{
 		Probes: []probe{
 			{event: "security_kernel_read_file", attach: kprobe, fn: "trace_security_kernel_read_file"},
 		},
+		Dependencies: dependencies{
+			tailCalls: []tailCall{
+				{mapName: "prog_array", mapIdx: tailSendBin, progName: "send_bin", tailType: CaptureModule},
+			},
+		},
 		Sets: []string{"lsm_hooks"},
 		Params: []trace.ArgMeta{
 			{Type: "const char*", Name: "pathname"},
@@ -6158,9 +6217,9 @@ var EventsDefinitions = map[int32]EventDefinition{
 		Probes:  []probe{},
 		Dependencies: dependencies{
 			tailCalls: []tailCall{
-				{mapName: "sys_exit_tails", mapIdx: uint32(DupEventID), progName: "sys_dup_exit_tail"},
-				{mapName: "sys_exit_tails", mapIdx: uint32(Dup2EventID), progName: "sys_dup_exit_tail"},
-				{mapName: "sys_exit_tails", mapIdx: uint32(Dup3EventID), progName: "sys_dup_exit_tail"},
+				{mapName: "sys_exit_tails", mapIdx: uint32(DupEventID), progName: "sys_dup_exit_tail", tailType: CaptureAlways},
+				{mapName: "sys_exit_tails", mapIdx: uint32(Dup2EventID), progName: "sys_dup_exit_tail", tailType: CaptureAlways},
+				{mapName: "sys_exit_tails", mapIdx: uint32(Dup3EventID), progName: "sys_dup_exit_tail", tailType: CaptureAlways},
 			},
 		},
 		Sets: []string{},
@@ -6187,6 +6246,12 @@ var EventsDefinitions = map[int32]EventDefinition{
 		Probes: []probe{
 			{event: "__kernel_write", attach: kprobe, fn: "trace_kernel_write"},
 			{event: "__kernel_write", attach: kretprobe, fn: "trace_ret_kernel_write"},
+		},
+		Dependencies: dependencies{
+			tailCalls: []tailCall{
+				{mapName: "prog_array", mapIdx: tailKernelWrite, progName: "trace_ret_kernel_write_tail", tailType: CaptureFile},
+				{mapName: "prog_array", mapIdx: tailSendBin, progName: "send_bin", tailType: CaptureFile},
+			},
 		},
 		Sets: []string{},
 		Params: []trace.ArgMeta{

--- a/pkg/ebpf/initialization/kconfig.go
+++ b/pkg/ebpf/initialization/kconfig.go
@@ -31,12 +31,12 @@ func LoadKconfigValues(kc *helpers.KernelConfig, isDebug bool) (map[helpers.Kern
 		if isDebug {
 			fmt.Fprintf(os.Stderr, "KConfig: warning: assuming kconfig values, might have unexpected behavior\n")
 		}
-		for key, _ := range kconfigUsed {
+		for key := range kconfigUsed {
 			values[key] = helpers.UNDEFINED
 		}
 		values[CONFIG_ARCH_HAS_SYSCALL_WRAPPER] = helpers.BUILTIN // assume CONFIG_ARCH_HAS_SYSCALL_WRAPPER is a BUILTIN option
 	} else {
-		for key, _ := range kconfigUsed {
+		for key := range kconfigUsed {
 			values[key] = kc.GetValue(key) // undefined, builtin OR module
 		}
 	}

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -583,16 +583,6 @@ func (t *Tracee) getFiltersConfig() uint32 {
 	return cFilterVal
 }
 
-// an enum that specifies the index of a function to be used in a bpf tail call
-// tail function indexes should match defined values in ebpf code for prog_array map
-const (
-	tailVfsWrite uint32 = iota
-	tailVfsWritev
-	tailSendBin
-	tailSendBinTP
-	tailKernelWrite
-)
-
 func (t *Tracee) populateBPFMaps() error {
 
 	// Set chosen events map according to events chosen by the user
@@ -772,29 +762,34 @@ func (t *Tracee) populateBPFMaps() error {
 
 	// Initialize tail call dependencies
 	tailCalls := make(map[tailCall]bool)
-	if t.config.Capture.FileWrite {
-		tailCalls[tailCall{mapName: "prog_array", mapIdx: tailVfsWrite, progName: "trace_ret_vfs_write_tail"}] = true
-		tailCalls[tailCall{mapName: "prog_array", mapIdx: tailVfsWritev, progName: "trace_ret_vfs_writev_tail"}] = true
-		tailCalls[tailCall{mapName: "prog_array", mapIdx: tailKernelWrite, progName: "trace_ret_kernel_write_tail"}] = true
-		tailCalls[tailCall{mapName: "prog_array", mapIdx: tailSendBin, progName: "send_bin"}] = true
-	}
-	if t.config.Capture.Module {
-		tailCalls[tailCall{mapName: "sys_enter_tails", mapIdx: uint32(InitModuleEventID), progName: "syscall__init_module"}] = true
-		tailCalls[tailCall{mapName: "prog_array_tp", mapIdx: tailSendBinTP, progName: "send_bin_tp"}] = true
-		tailCalls[tailCall{mapName: "prog_array", mapIdx: tailSendBin, progName: "send_bin"}] = true
-	}
-	if t.config.Capture.Mem {
-		tailCalls[tailCall{mapName: "prog_array", mapIdx: tailSendBin, progName: "send_bin"}] = true
-	}
 	for e := range t.events {
 		for _, tailCall := range EventsDefinitions[e].Dependencies.tailCalls {
 			tailCalls[tailCall] = true
 		}
 	}
 	for tailCall := range tailCalls {
-		err := t.initTailCall(tailCall.mapName, tailCall.mapIdx, tailCall.progName)
-		if err != nil {
-			return fmt.Errorf("failed to initialize tail call: %w", err)
+		init := false
+		switch tailCall.tailType {
+		case CaptureFile:
+			if t.config.Capture.FileWrite {
+				init = true
+			}
+		case CaptureModule:
+			if t.config.Capture.Module {
+				init = true
+			}
+		case CaptureMem:
+			if t.config.Capture.Mem {
+				init = true
+			}
+		case CaptureAlways:
+			init = true
+		}
+		if init {
+			err = t.initTailCall(tailCall.mapName, tailCall.mapIdx, tailCall.progName)
+			if err != nil {
+				return fmt.Errorf("failed to initialize tail call: %w", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
Categorize tail calls and always declare them as event dependencies.
This makes it more clear to know which events depends on what tail call
and which tail call will be enabled if a configuration option is set
(like capturing file writes, or capturing memory operations).